### PR TITLE
Add check for file existence

### DIFF
--- a/src/arkane-application-cleaner
+++ b/src/arkane-application-cleaner
@@ -16,6 +16,10 @@ for file in *; do
 	else
 		cd $app_dir_path
 
+		if [[ ! -f "$target" ]]; then
+        		continue
+    		fi
+
 		if ! grep -qs "$contain" "$target"; then
 			printf $contain >> $target
 


### PR DESCRIPTION
In KDE I saw empty desktop entries that remain in the menu, I don't know why KDE shows desktop entries if they only have 'NotShowIn=GNOME;KDE;Pantheon;' but checking for file existence fixes this